### PR TITLE
Sum report mods: treescale + auto scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
  
  
 ## Version 0.5.0, 29-11-21
- - outbreaker now creates an output summary report sumamrizing the number of input sequences, SNP distance patterns relative to the focal sequences inputs, as well as basic rendering of the phylogenetic trees. The report is flexible: it will modify the outputs accordingly if either background sequences are not supplied or SNPs only analysis is not conducted. requires a majoy environment upgrade, specifically with regards to R and Bioconductor dependencies through conda
+ - outbreaker now creates an output summary report summarizing the number of input sequences, SNP distance patterns relative to the focal sequences inputs, as well as basic rendering of the phylogenetic trees. The report is flexible: it will modify the outputs accordingly if either background sequences are not supplied or SNPs only analysis is not conducted. requires a majoy environment upgrade, specifically with regards to R and Bioconductor dependencies through conda
   
 
 ## Version 0.6.0, 01-12-21
@@ -41,4 +41,9 @@
 
 ## Minor Version 0.6.1, 02-12-21
  - The output summary report is now an optional output to avoid rendering a large report by default with a
-   very large dataset. This can be enabled with ```--report```. By default the report is not generated. 
+   very large dataset. This can be enabled with ```--report```. By default the report is not generated.
+   
+## Minor Version 0.6.2, 07-12-21
+ - ```outbreaker -v``` or ```outbreaker --version``` will now show the current version, then exit. 
+ - In the summary report, the trees are automatically scaled with xlim to ensure that the tree labels are always visible, no matter the length of the branch
+ - In the summary report, a treescale was added for the trees that renders in either the bottom right or top right, depending on where the longest branches are. This was done to avoid having the treescale overlapping a tiplab. 

--- a/outbreaker/__init__.py
+++ b/outbreaker/__init__.py
@@ -1,2 +1,2 @@
 _program = "outbreaker"
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/outbreaker/workflows/outbreaker.smk
+++ b/outbreaker/workflows/outbreaker.smk
@@ -318,12 +318,14 @@ rule summary_report:
         snp_tree_read = absol_path(os.path.join(config["outdir"], config["prefix"] + "_snps_only.contree")) if config["snps_only"] else [],
         snipit_read = absol_path(os.path.join(config["outdir"], config["prefix"] + "_snipit.jpg")),
         renamed = convertPythonBooleanToR(config["rename"]),
-        names_sheet_read = absol_path(config["names_csv"]) if config["names_csv"] else []
+        names_sheet_read = absol_path(config["names_csv"]) if config["names_csv"] else [],
+        prefix_input = str(config["prefix"]),
+        report_output = absol_path(os.path.join(config["outdir"])) + "/"
     run:
         if config["report"]:
             shell( 
             """
-            Rscript -e \"rmarkdown::render(input = '{params.script}', params = list(focal_list = '{params.focal_read}', background_list = '{params.background_read}',     snp_dists = '{params.snp_read}', snp_tree = '{params.snp_tree_read}', full_tree = '{params.full_tree_read}', snipit = '{params.snipit_read}', renamed = '{params.renamed}', names_csv = '{params.names_sheet_read}'), output_file = '{params.output}')\"
+            Rscript -e \"rmarkdown::render(input = '{params.script}', params = list(focal_list = '{params.focal_read}', background_list = '{params.background_read}',     snp_dists = '{params.snp_read}', snp_tree = '{params.snp_tree_read}', full_tree = '{params.full_tree_read}', snipit = '{params.snipit_read}', renamed = '{params.renamed}', names_csv = '{params.names_sheet_read}', outbreak_prefix = '{params.prefix_input}', outbreak_directory = '{params.report_output}'), output_file = '{params.output}')\"
             """)
   
         

--- a/outbreaker/workflows/outbreaker_summary_report.Rmd
+++ b/outbreaker/workflows/outbreaker_summary_report.Rmd
@@ -25,6 +25,10 @@ params:
     value: ""
   renamed: 
     value: FALSE
+  outbreak_prefix: 
+    value: ""
+  outbreak_directory: 
+    value: ""
 output:
   html_document:
     toc: yes
@@ -54,6 +58,18 @@ library(stringr)
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, comment = NA)
 ```
+
+## Run Information
+
+Please use the files found in the directory below to perform more detailed analysis for this outbreak. 
+
+
+Outbreak identifier (prefix used at runtime): **`r format (as.character(params$outbreak_prefix))`**
+<br>
+Run output directory: **`r format (as.character(params$outbreak_directory))`**
+
+<br>
+<br>
 
 ## Summary Statistics
 
@@ -394,7 +410,28 @@ Focal sequences are coloured in red, while background sequences are coloured in 
 
 ```{r echo=F, fig.height=11, fig.width=18, message=FALSE, warning=FALSE}
 
-annotated_tree <- ggtree(tree, size = 0.5) %<+% tr.df.labs +
+# if the lowest point on the tree is over the default legend spot,
+# move it up to the top (95% of the way)
+# otherwise, keep at 95% off the floor of the tree
+
+# if the x where the y min occurs is within 80% of the max x, move to top
+if (subset(tr.df, y == min(tr.df$y))$x > 0.8*(max(tr.df$x)) |
+    # if the y where the max x occurs is within 80% of the min y value,
+    # move to top
+    min(subset(tr.df, x == max(tr.df$x))$y) <= (sd(tr.df$y))*(
+      min(tr.df$y) + 0.000001)) {
+  y_coord <- 0.95*max(tr.df$y)
+} else {
+  # otherwise, keep on the bottom
+  y_coord <- 0.95*min(tr.df$y)
+}
+
+
+annotated_tree_scaled <- ggtree(tree, size = 0.5) + xlim(c(0, 
+                                      1.15*max(tr.df$x))) +
+  geom_treescale(x = max(tr.df$x), y = y_coord, fontsize = 8)
+
+annotated_tree <- annotated_tree_scaled %<+% tr.df.labs +
   geom_tiplab(aes(x=x, subset=category == "Focal_Sequence", label = label),  size = 3, offset = 0, colour = "red") +
   geom_tiplab(aes(x=x, subset=category == "Background_Sequence", label = label),  size = 3, offset = 0, colour = "black") +
   theme(plot.margin = unit(c(0,0,0,0), "cm"),
@@ -411,7 +448,7 @@ annotated_tree <- ggtree(tree, size = 0.5) %<+% tr.df.labs +
         legend.key.size = unit(3,"lines")) +
   guides(color = guide_legend(override.aes = list(size = 1.75)))
 
-annotated_tree
+annotated_tree + geom_treescale(x = 0.1, y = 0.2, fontsize = 2)
 
 ```
 
@@ -451,7 +488,26 @@ if (file_ext(params$focal_list) %in% fasta_extensions) {
    }
 }
 
-  annotated_tree_snps <- ggtree(tree_snps, size = 0.5) %<+% tr.df.labs +
+# if the lowest point on the tree is over the default legend spot,
+# move it up to the top (95% of the way)
+# otherwise, keep at 95% off the floor of the tree
+
+# if the x where the y min occurs is within 80% of the max x, move to top
+if (subset(tr.df, y == min(tr.df$y))$x > 0.8*(max(tr.df$x)) |
+    # if the y where the max x occurs is within 80% of the min y value,
+    # move to top
+    min(subset(tr.df, x == max(tr.df$x))$y) <= (sd(tr.df$y))*(
+      min(tr.df$y) + 0.000001)) {
+  y_coord <- 0.95*max(tr.df$y)
+} else {
+  # otherwise, keep on the bottom
+  y_coord <- 0.95*min(tr.df$y)
+}
+
+annotated_tree_scaled <- ggtree(tree_snps, size = 0.5) + xlim(c(0, 
+                                      1.15*max(tr.df$x))) +
+  geom_treescale(x = max(tr.df$x), y = y_coord, fontsize = 8)
+  annotated_tree_snps <- annotated_tree_scaled %<+% tr.df.labs +
   geom_tiplab(aes(x=x, subset=category == "Focal_Sequence", label = label),  size = 3, offset = 0, colour = "red") +
   geom_tiplab(aes(x=x, subset=category == "Background_Sequence", label = label),  size = 3, offset = 0, colour = "black") +
   theme(plot.margin = unit(c(0,0,0,0), "cm"),


### PR DESCRIPTION
- In the summary report, the trees are automatically scaled with xlim to ensure that the tree labels are always visible, no matter the length of the branch. Closes #6 
- In the summary report, a treescale was added for the trees that renders in either the bottom right or top right, depending on where the longest branches are. This was done to avoid having the treescale overlapping a tiplab. Closes #8. 